### PR TITLE
migrated scheduler funcs to separate API

### DIFF
--- a/os.c
+++ b/os.c
@@ -35,43 +35,6 @@ stack_base(struct thread *this)
 
 
 void
-os_init(void)
-{
-  int i;
-  __disable_interrupt(); // disable interrupts until os_run
-  preempt_reset();
-  for (i = 0; i < NUMTHREADS; ++i)
-    thread_fg_set(&threads[i], THRD_AVAIL_BIT__, true);
-}
-
-void
-os_run(void)
-{
-//  if (run_ct) {
-//    preempt_init();
-//    context_load(&run_ptr->ctx);
-//  } else {
-//    for (;;);
-//  }
-  preempt_init();
-  preempt_firstrun();
-  panic(0);
-}
-
-void
-os_thread_set(void (*routine1)(void),
-              void (*routine2)(void))
-{
-  thrd_t thr1, thr2;
-  thrd_create(&thr1, (thrd_start_t) routine1, NULL);
-  thrd_create(&thr2, (thrd_start_t) routine2, NULL);
-
-  thrd_join(thr1, NULL);
-  thrd_join(thr2, NULL);
-}
-
-
-void
 panic(c)
     int c;
 {

--- a/os.h
+++ b/os.h
@@ -111,7 +111,6 @@ struct thread {
  * Global variables
  */
 uint16_t num_ctx_switches;
-struct thread threads[NUMTHREADS];
 unsigned run_ct;
 struct thread *run_ptr; // currently running thread
 
@@ -120,10 +119,11 @@ struct thread *run_ptr; // currently running thread
  */
 
 /* scheduler impl (defined in config.h) */
-extern void schedule(void);
-extern void sched_add(struct thread *);
-extern void sched_start(void);
-extern int link(void);
+extern void schedule(void); // called in the context switcher
+extern struct thread *sched_new(void); // Retrieve a new struct thread
+extern void sched_add(struct thread *); // Mark a thread as runnable
+extern void sched_start(void); // Start preemption if not running already
+extern void sched_init(void); // first call upon interaction with scheduler
 
 /* preempt.c */
 inline void preempt_trigger(void);
@@ -132,9 +132,6 @@ void preempt_reset(void);
 
 /* os.c */
 void panic(int) __attribute__ ((noreturn));
-void os_init(void);
-void os_run(void) __attribute__ ((noreturn));
-void os_thread_set(void (*routine1)(void), void (*routine2)(void)); // TODO: remove
 uint16_t *stack_base(struct thread *this);
 
 /* osasm.s */

--- a/os.h
+++ b/os.h
@@ -124,6 +124,7 @@ extern struct thread *sched_new(void); // Retrieve a new struct thread
 extern void sched_add(struct thread *); // Mark a thread as runnable
 extern void sched_start(void); // Start preemption if not running already
 extern void sched_init(void); // first call upon interaction with scheduler
+extern void sched_thread_exit(void); // notify scheduler that run_ptr has completed
 
 /* preempt.c */
 inline void preempt_trigger(void);

--- a/rr.c
+++ b/rr.c
@@ -4,10 +4,59 @@
 
 #include "os.h"
 
+static int link(void);
+
+struct thread_node {
+  struct thread *this, *next;
+};
+
+struct thread threads[NUMTHREADS];
+
 void
 schedule(void)
 {
   run_ptr =  run_ptr->next;
+}
+
+struct thread *
+sched_new(void)
+{
+  int i;
+  for (i = 0; i < NUMTHREADS; i++) // find an available thread
+    if (thread_fg_get(&threads[i], THRD_AVAIL_BIT__))
+      break;
+  if (i == NUMTHREADS) {
+    __enable_interrupt();
+    return NULL;
+  }
+  return &threads[i];
+}
+
+void
+sched_add(struct thread *thr)
+{
+  (void) link();
+}
+
+void
+sched_start(void)
+{
+  if (status == SYS_UNINITIALIZED) {
+    status = SYS_RUNNING;
+    __enable_interrupt();
+    preempt_init();
+    preempt_firstrun();
+    panic(0);
+  }
+}
+
+void
+sched_init(void) {
+  int i;
+  __disable_interrupt(); // disable interrupts until os_run
+  preempt_reset();
+  for (i = 0; i < NUMTHREADS; ++i)
+    thread_fg_set(&threads[i], THRD_AVAIL_BIT__, true);
 }
 
 int

--- a/rr.c
+++ b/rr.c
@@ -59,6 +59,16 @@ sched_init(void) {
     thread_fg_set(&threads[i], THRD_AVAIL_BIT__, true);
 }
 
+void
+sched_thread_exit(void)
+{
+  thread_fg_set(run_ptr, THRD_AVAIL_BIT__, true);
+  (void) link();
+  schedule(); // TODO: Return value from thread needs to be saved somewhere other than context, b/c it could be overwritten
+  preempt_firstrun();
+  __enable_interrupt();
+}
+
 int
 link(void)
 {

--- a/threads.c
+++ b/threads.c
@@ -7,7 +7,6 @@
 ////////////////////////////
 
 #include "os.h"
-#include "thread.h"
 
 int
 thrd_create(thrd_t *thr, thrd_start_t func, void *arg)

--- a/threads.c
+++ b/threads.c
@@ -90,8 +90,11 @@ void
 thrd_exit(int res)
 {
   if (bsem_trywait(run_ptr->flags.raw, THRD_SEM_BIT__) == 0) {
+    __disable_interrupt();
     run_ptr->ctx.r12 = (word_t) res;
     bsem_post(&run_ptr->flags.raw, THRD_SEM_BIT__);
+    __disable_interrupt();
+    sched_thread_exit();
   } else {
     panic(9); // thread has exited twice??
   }


### PR DESCRIPTION
The scheduler now should have a reusable interface in `os.h` that can be implemented by multiple scheduling algorithms. The reference implementation is `rr.c`.